### PR TITLE
NeoTextFeild Controller Implementation missing. Added the controller missing implementation 

### DIFF
--- a/lib/components/neo_text_field.dart
+++ b/lib/components/neo_text_field.dart
@@ -48,6 +48,7 @@ class NeoTextField extends StatelessWidget {
         ],
       ),
       child: TextField(
+        controller: controller, 
         cursorColor: foregroundColor,
         style: TextStyle(
           color: foregroundColor,
@@ -59,7 +60,11 @@ class NeoTextField extends StatelessWidget {
           ),
           hintText: hintText,
           hintStyle: TextStyle(
-            color: foregroundColor,
+            color: foregroundColor?.withOpacity(0.6),
+          ),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 12,
           ),
         ),
       ),

--- a/lib/components/neo_text_field.dart
+++ b/lib/components/neo_text_field.dart
@@ -62,10 +62,7 @@ class NeoTextField extends StatelessWidget {
           hintStyle: TextStyle(
             color: foregroundColor?.withOpacity(0.6),
           ),
-          contentPadding: const EdgeInsets.symmetric(
-            horizontal: 16,
-            vertical: 12,
-          ),
+
         ),
       ),
     );


### PR DESCRIPTION
```
      child: TextField(
        controller: controller, 
```

this was missing.